### PR TITLE
Fix title block typo

### DIFF
--- a/currenfy/apps/trader/templates/trader/base.html
+++ b/currenfy/apps/trader/templates/trader/base.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>{% block titlte %}{% endblock%}</title>
+    <title>{% block title %}{% endblock%}</title>
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <!-- Bootstrap core CSS -->


### PR DESCRIPTION
## Summary
- fix typo in base template block name

## Testing
- `python manage.py migrate` *(fails: BaseRouter.register() unexpected keyword argument)*
- `python manage.py test` *(fails: BaseRouter.register() unexpected keyword argument)*

------
https://chatgpt.com/codex/tasks/task_e_684003ea448483218e04aebc2d546773