### PR TITLE
Fix typo in BookedTrades comment

### DIFF
--- a/currenfy/apps/booked/models.py
+++ b/currenfy/apps/booked/models.py
@@ -51,5 +51,5 @@ def booked_trades_pre_save_handler(sender, instance, *args, **kwargs):
                     collision = False
                 if not collision:
                     instance.ID = id_candidate
-    # consistency asurance
+    # consistency assurance
     instance.buy_amount = instance.sell_amount * instance.rate


### PR DESCRIPTION
## Summary
- fix a typo in BookedTrades comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68400d5424908321bd6376191ebd2f59