### PR TITLE
Fix API endpoint and tests

### DIFF
--- a/currenfy/apps/api/tests/test_api.py
+++ b/currenfy/apps/api/tests/test_api.py
@@ -43,6 +43,7 @@ class ApiTest(CurrenfyTest):
             checks booked trade is correct
         """
         self.assertTrue(item.get('ID', None))
+        self.check_id(item.get('ID'))
         self.assertTrue(item.get('sell_amount', None))
         self.assertTrue(item.get('sell_currency', None))
         self.assertTrue(item.get('buy_amount', None))

--- a/currenfy/apps/api/urls.py
+++ b/currenfy/apps/api/urls.py
@@ -5,7 +5,7 @@ from . import views
 
 
 router = routers.SimpleRouter()
-router.register(r'booked', views.BookedTradesSet, base_name='booked')
+router.register(r'booked', views.BookedTradesSet, basename='booked')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/currenfy/apps/api/views.py
+++ b/currenfy/apps/api/views.py
@@ -36,8 +36,12 @@ class SymbolsView(ListAPIView):
         return Response(content, status.HTTP_200_OK)
 
 
-def rate_without_params():
-    raise Exception('Not allowed get rate without currency exchange symbols.')
+def rate_without_params(request):
+    """Return a 400 response when currency symbols are missing."""
+    content = {
+        'error': 'Not allowed get rate without currency exchange symbols.'
+    }
+    return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
 class RateView(ListAPIView):
     """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,6 @@ pylint==2.1.1
 pytz==2018.5
 requests==2.32.2
 six==1.11.0
-typed-ast==1.1.0
+typed-ast==1.5.5
 urllib3>=1.24.2
 wrapt==1.10.11


### PR DESCRIPTION
## Summary
- make view's rate_without_params accept `request`
- return an HTTP 400 response for missing rate params
- register the API router using `basename`
- call `check_id` on booked trade items in tests
- update typed-ast version for Python 3.11 compatibility

## Testing
- `pip install -r requirements-dev.txt`
- `python manage.py test` *(fails: JSONDecodeError when hitting Fixer.io API)*

------
https://chatgpt.com/codex/tasks/task_e_683fe73ddbd483218294f671d87c7e53